### PR TITLE
Css modules: Convert hyphenated classes to camelCase

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-config-vacuumlabs",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Default Webpack 2 & 3 config we use in vacuumlabs.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/styles.js
+++ b/src/styles.js
@@ -7,7 +7,7 @@ const _loaders = {
   scss: 'sass-loader',
   sass: 'sass-loader?indentedSyntax',
 }
-const cssModulesConfig = '?modules&localIdentName=[path][name]---[local]---[hash:base64:8]'
+const cssModulesConfig = '?modules&camelCase=dashes&localIdentName=[path][name]---[local]---[hash:base64:8]'
 
 const postcssLoader = {
   loader: 'postcss-loader',


### PR DESCRIPTION
Keep the css class-names clean. `camelCase` is not used by convention in css. 

I have only enabled it for modules. For importing global css it shouldn't be used or needed.
I also dumped the minor version number, since it might break css for some projects.
Basically what this does is:
```css
.my-class {
  color: blue;
}
```
When imported as css module:
```js
import styles from './Styles.css?module'
...
<span class={styles.myClass}>something</span>
```

Usage for example:
https://github.com/vacuumlabs/vacuumpeople/pull/147